### PR TITLE
fixed a crash when an Altar recipe failed to fully consume its inputs

### DIFF
--- a/src/main/java/com/almostreliable/summoningrituals/inventory/AltarInventory.java
+++ b/src/main/java/com/almostreliable/summoningrituals/inventory/AltarInventory.java
@@ -191,7 +191,7 @@ public class AltarInventory implements ItemHandler {
         if (actualRemoved < toRemove) {
             items.clear();
             for (int i = 0; i < itemBackup.size(); i++) {
-                items.add(i, itemBackup.get(i));
+                items.set(i, itemBackup.get(i));
             }
             return false;
         }


### PR DESCRIPTION
the inventory rollback called add on the fixed-size list instead of set

Fixes https://github.com/AlmostReliable/summoningrituals/issues/38